### PR TITLE
Mistake in docs, the proper param is `id` not `inventory_id`

### DIFF
--- a/api.php
+++ b/api.php
@@ -181,7 +181,7 @@ class EchoPHP {
 
         // set the parameters
         $request = [
-            'inventory_id' => $eid,
+            'id' => $eid,
             'adjusted_price' => $price ];
 
         // attempt to remove the card


### PR DESCRIPTION
I'll update the API to fix the typo
